### PR TITLE
Add addressable gem requirement

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -3,6 +3,8 @@
 # version: 0.1
 # authors: Ryan Fox
 
+gem "addressable", "2.3.6"
+
 after_initialize do
 
   SYSTEM_GUARDIAN = Guardian.new(User.find_by(id: -1))


### PR DESCRIPTION
This gem only exists when running Discourse master. So it should be explicitly required in this plugin until it's no longer just in master.
